### PR TITLE
Symfony 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,30 @@ matrix:
         - SYMFONY_VERSION=5.0.*
         - MONOLOG_VERSION=^2.0
 
+    - language: php
+      php: 8.0
+      env:
+        - SYMFONY_VERSION=5.0.*
+        - MONOLOG_VERSION=^2.0
+
+    - language: php
+      php: 8.0
+      env:
+        - SYMFONY_VERSION=6.0.*
+        - MONOLOG_VERSION=^2.0
+
+    - language: php
+      php: 8.1
+      env:
+        - SYMFONY_VERSION=5.0.*
+        - MONOLOG_VERSION=^2.0
+
+    - language: php
+      php: 8.1
+      env:
+        - SYMFONY_VERSION=6.0.*
+        - MONOLOG_VERSION=^2.0
+
 before_script:
   - phpenv config-add travis.php.ini
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -12,19 +12,18 @@
         "phpcr/phpcr-migrations": "^1.1",
         "phpcr/phpcr-implementation": "^2.1",
         "doctrine/phpcr-bundle": "^1.3 || ^2.0",
-        "symfony/config": "^2.8 || ^3.4 || ^4.0 || ^5.0",
-        "symfony/console": "^2.8 || ^3.4 || ^4.0 || ^5.0",
-        "symfony/dependency-injection": "^2.8 || ^3.4 || ^4.0 || ^5.0",
-        "symfony/http-kernel": "^2.8 || ^3.4 || ^4.0 || ^5.0"
+        "symfony/config": "^2.8 || ^3.4 || ^4.0 || ^5.0 || ^6.0",
+        "symfony/console": "^2.8 || ^3.4 || ^4.0 || ^5.0 || ^6.0",
+        "symfony/dependency-injection": "^2.8 || ^3.4 || ^4.0 || ^5.0 || ^6.0",
+        "symfony/http-kernel": "^2.8 || ^3.4 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
-        "doctrine/phpcr-bundle": "^1.3 || ^2.0",
         "doctrine/phpcr-odm": "^1.4",
-        "symfony/symfony": "^2.8 || ^3.4 || ^4.0 || ^5.0",
+        "symfony/symfony": "^2.8 || ^3.4 || ^4.0 || ^5.0 || ^6.0",
         "symfony/monolog-bundle": "^2.0 || ^3.0",
         "symfony/phpunit-bridge": "^5.0.5",
-        "symfony-cmf/testing": "^2.1 || ^3.0"
+        "symfony-cmf/testing": "^2.1 || ^3.0 || ^4.0"
     },
     "conflict": {
         "symfony/symfony": "3.4.15"


### PR DESCRIPTION
- allowed symfony 6 in version constraints
- added ci-config for php 8.0 & 8.1

requires:
- https://github.com/jackalope/jackalope-fs/pull/29
- https://github.com/phpcr/phpcr-migrations/pull/14
