### PR TITLE
Add text matrix for PHP 8.2 and Monolog 3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,10 @@ jobs:
                       symfony-version: '^6.0'
                       monolog-version: '^2.0'
 
+                    - php-version: '8.2'
+                      symfony-version: '^6.0'
+                      monolog-version: '^3.0'
+
         steps:
             - name: Checkout project
               uses: actions/checkout@v2


### PR DESCRIPTION
Currently PHP 8.2 and Monolog 3 is not tested.