### PR TITLE
Test against phpcr bundle 3.0@dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
-        "doctrine/phpcr-odm": "^2.0@dev",
+        "doctrine/phpcr-odm": "^1.4 || ^2.0@dev",
         "symfony/symfony": "^4.4 || ^5.4 || ^6.0",
         "symfony/monolog-bundle": "^2.0 || ^3.0",
         "symfony/phpunit-bridge": "^5.4 || ^6.0",


### PR DESCRIPTION
This tests the bundle against changes of "doctrine/phpcr-bundle": "^3.0@dev"
 and "doctrine/phpcr-odm": "^2.0@dev".